### PR TITLE
test/fix/ship_spec.rb: align indentation for ends.

### DIFF
--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -119,6 +119,6 @@ RSpec.describe Board do
                                         "C . . . . \n" +
                                         "D . . . . \n")
     end
-
-    end
+  end
+  
 end


### PR DESCRIPTION
fixed alignment of ends at the end of ship_spec.rb file